### PR TITLE
Fix dockerized pip deadlock + boot2docker helper scripts

### DIFF
--- a/bin/boot2docker-install-python.sh
+++ b/bin/boot2docker-install-python.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+#http://stackoverflow.com/questions/30605742/issues-getting-ansible-to-work-with-boot2docker
+# To use Ansible in boot2docker, we must install python in boot2docker (it's based on Tiny Core Linux)
+boot2docker ssh "wget http://www.tinycorelinux.net/6.x/x86/tcz/python.tcz && tce-load -i python.tcz && rm -f python.tcz"

--- a/bin/docker-run
+++ b/bin/docker-run
@@ -208,6 +208,15 @@ if [[ "$CMD" == *"/init" ]]; then
 else
   DOCKER_INTERACT_ARGS='-ti --rm=true'
 
+  # Always use sudo when running pip commands inside container
+  # If pip is run without sudo it hangs in deadlock condition
+  if [ -n "$DOCKER_MACHINE_NAME" ]; then
+    EXPORT_DOCKER_PIP_USE_SUDO='export PIP_USE_SUDO=1; '
+  else
+    # unset this for security purposes if running on native host
+    unset EXPORT_DOCKER_PIP_USE_SUDO
+  fi
+
   # Create script to run inside docker container
 cat << EOF > ${RUN_SCRIPT}
 #!/usr/bin/env bash
@@ -292,7 +301,8 @@ if [[ "\$SSH_AUTH_SOCK" == \$SSH_AUTH_SOCK_MAGIC_PATH ]]; then
 fi
 
 su - ${MY_USERNAME} -c \
-'$EXPORT_DOCKER_SSH_AGENT_AUTH_SOCK cd ${REPO_BASE} && \
+'$EXPORT_DOCKER_SSH_AGENT_AUTH_SOCK $EXPORT_DOCKER_PIP_USE_SUDO \
+cd ${REPO_BASE} && \
 source bin/setup-ansible-env.sh && [ -e /opt/ansible/ansible/hacking/env-setup ] && source /opt/ansible/ansible/hacking/env-setup ; \
 ${CMD}'
 EOF

--- a/bin/docker-run
+++ b/bin/docker-run
@@ -157,16 +157,6 @@ if env | grep -q SSH_AUTH_SOCK && test -n "${DOCKER_MACHINE_NAME}"; then
   [ $? -eq 0 ] || echo "ERROR: DM_AGENT_SOCK path: $DM_AGENT_SOCK does not exist... could not forward SSH_AUTH_SOCK into docker-machine!  Is your ssh-agent running?"
 fi
 
-# TODO: Figure out some way of supporting "Docker for Mac" to pass through ssh-agent socket?
-#       As the latest version of OSX native Docker does not support socket communication over the Hypervisor boundary, we're stuck!
-#       The official documentation states:
-#         "Socket files and named pipes only transmit between containers and between OS X processes – no transmission across the hypervisor is supported, yet."
-# References:
-#   - https://docs.docker.com/docker-for-mac/osxfs/#file-types
-#   - https://github.com/docker/for-mac/issues/410
-#   - https://github.com/docker/for-mac/issues/483
-#   - https://docs.docker.com/docker-for-mac/troubleshoot/#/known-issues
-# TODO: Watch these bug tickets to see if they add it ^^
 
 # If Docker Host is running ssh-agent, import SSH_AUTH_SOCK into container env
 if env | grep -q SSH_AUTH_SOCK ; then

--- a/bin/docker_machine_create_dm.sh
+++ b/bin/docker_machine_create_dm.sh
@@ -19,5 +19,5 @@ BOOT2DOCKER_URL='https://github.com/silver886/boot2docker/releases/download/v20.
 
 docker-machine create --driver virtualbox \
   --virtualbox-boot2docker-url "$BOOT2DOCKER_URL" \
-  --virtualbox-hostonly-cidr "192.168.56.100/24" \
+  --virtualbox-hostonly-cidr "192.168.56.100/21" \
   dm

--- a/bin/docker_machine_create_dm.sh
+++ b/bin/docker_machine_create_dm.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+docker_machine_state() {
+  docker_machine_name="$1"
+  docker-machine ls --filter "Name=$docker_machine_name" --format '{{.State}}'
+}
+
+errorout() {
+  echo -e "\x1b[31;1mERROR:\x1b[0m ${1}"; exit 1
+}
+
 # Notes:
 #  - Both docker-machine and boot2docker
 #    are marked as Deprecated by the original authors
@@ -21,3 +30,23 @@ docker-machine create --driver virtualbox \
   --virtualbox-boot2docker-url "$BOOT2DOCKER_URL" \
   --virtualbox-hostonly-cidr "192.168.56.100/21" \
   dm
+
+eval $(docker-machine env dm)
+
+DOCKER_MACHINE_NAME=$(docker-machine active 2>/dev/null)
+[ -z $DOCKER_MACHINE_NAME ] && DOCKER_MACHINE_NAME=$(docker-machine active | head -n1)
+[ -z $DOCKER_MACHINE_NAME ] && errorout "Cannot find active docker-machine name... make sure the VM is running"
+
+echo "Creating vboxsf group INSIDE docker-machine VM: $DOCKER_MACHINE_NAME"
+docker-machine ssh $DOCKER_MACHINE_NAME "sudo addgroup -g 20 vboxsf"
+echo "Adding docker user to vboxsf group"
+docker-machine ssh $DOCKER_MACHINE_NAME "sudo addgroup docker vboxsf"
+
+echo "Starting VBoxService automount /Users shared folder"
+docker-machine ssh $DOCKER_MACHINE_NAME "sudo VBoxService --only-automount"
+# TODO: Fix "magic"? automount path + uid / gid setup
+# Reference:
+#  -  https://github.com/docker/machine/blob/b170508bf44c3405e079e26d5fdffe35a64c6972/drivers/virtualbox/virtualbox.go#L445
+docker-machine ssh $DOCKER_MACHINE_NAME "sudo umount /sf_Users"
+docker-machine ssh $DOCKER_MACHINE_NAME "sudo mkdir /Users; sudo mount -t vboxsf -o uid=$(id -u),gid=$(id -g) Users /Users"
+docker-machine ssh $DOCKER_MACHINE_NAME "sudo mount -t vboxsf -o uid=$(id -u),gid=$(id -g) Users /Users"

--- a/bin/docker_machine_create_dm.sh
+++ b/bin/docker_machine_create_dm.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Notes:
+#  - Both docker-machine and boot2docker
+#    are marked as Deprecated by the original authors
+#  - Docker for Mac is now recommended instead
+#  - Yet, sometimes a minimal Linux Docker VM is still useful!
+#  - Luckily silver886 has a fork which appears to be updating the boot2docker.iso
+#  - As of VirtualBox 6.1.28,
+#    host-only networks are restricted to 192.168.56.0/21 by default
+#    References:
+#     - https://github.com/hashicorp/nomad/pull/11561
+#     - https://www.virtualbox.org/manual/ch06.html#network_hostonly
+
+# Create docker-machine 'dm' with:
+#  - Docker v20.10.11
+# Source: https://github.com/silver886/boot2docker/releases/tag/v20.10.11
+BOOT2DOCKER_URL='https://github.com/silver886/boot2docker/releases/download/v20.10.11/boot2docker.iso'
+
+docker-machine create --driver virtualbox \
+  --virtualbox-boot2docker-url "$BOOT2DOCKER_URL" \
+  --virtualbox-hostonly-cidr "192.168.56.100/24" \
+  dm

--- a/bin/docker_machine_create_dm.sh
+++ b/bin/docker_machine_create_dm.sh
@@ -50,3 +50,8 @@ docker-machine ssh $DOCKER_MACHINE_NAME "sudo VBoxService --only-automount"
 docker-machine ssh $DOCKER_MACHINE_NAME "sudo umount /sf_Users"
 docker-machine ssh $DOCKER_MACHINE_NAME "sudo mkdir /Users; sudo mount -t vboxsf -o uid=$(id -u),gid=$(id -g) Users /Users"
 docker-machine ssh $DOCKER_MACHINE_NAME "sudo mount -t vboxsf -o uid=$(id -u),gid=$(id -g) Users /Users"
+
+# Fix broken tce-load mirror command
+# NOTE: Check mirror URL works when gathered from:
+#       . /etc/init.d/tc-functions ; set -x; getMirror ; set +x
+docker-machine ssh $DOCKER_MACHINE_NAME "sudo /bin/sed -i'' -e 's/VERSION_ID=.*/VERSION_ID=12.0/'  /etc/os-release"

--- a/bin/docker_machine_install_python.sh
+++ b/bin/docker_machine_install_python.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+#http://stackoverflow.com/questions/30605742/issues-getting-ansible-to-work-with-boot2docker
+# To use Ansible in docker-machine, we must install python in docker-machine VM (it's based on Tiny Core Linux)
+docker-machine ssh "wget http://www.tinycorelinux.net/6.x/x86/tcz/python.tcz && tce-load -i python.tcz && rm -f python.tcz"

--- a/bin/docker_machine_install_python.sh
+++ b/bin/docker_machine_install_python.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
-#http://stackoverflow.com/questions/30605742/issues-getting-ansible-to-work-with-boot2docker
+# http://stackoverflow.com/questions/30605742/issues-getting-ansible-to-work-with-boot2docker
+
+docker_machine_state() {
+  docker_machine_name="$1"
+  docker-machine ls --filter "Name=$docker_machine_name" --format '{{.State}}'
+}
+
+DOCKER_MACHINE_NAME=$(docker-machine active 2>/dev/null)
+[ -z $DOCKER_MACHINE_NAME ] && DOCKER_MACHINE_NAME=$(docker-machine ls --filter 'driver=virtualbox' --format '{{.Name}}' | head -n1)
+
+[[ "$(docker-machine status $DOCKER_MACHINE_NAME)" != 'Running' ]] && docker-machine start $DOCKER_MACHINE_NAME
+
 # To use Ansible in docker-machine, we must install python in docker-machine VM (it's based on Tiny Core Linux)
-docker-machine ssh "wget http://www.tinycorelinux.net/6.x/x86/tcz/python.tcz && tce-load -i python.tcz && rm -f python.tcz"
+echo "Installing qemu-arm-static to /usr/bin/qemu-arm-static INSIDE docker-machine VM: $DOCKER_MACHINE_NAME"
+docker-machine ssh $DOCKER_MACHINE_NAME "wget http://www.tinycorelinux.net/6.x/x86/tcz/python.tcz && tce-load -i python.tcz && rm -f python.tcz"

--- a/bin/docker_machine_mount_shares.sh
+++ b/bin/docker_machine_mount_shares.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# From playbooks/dev_vm/README.md
+
+docker_machine_state() {
+  docker_machine_name="$1"
+  docker-machine ls --filter "Name=$docker_machine_name" --format '{{.State}}'
+}
+
+
+DOCKER_MACHINE_NAME=$(docker-machine active 2>/dev/null)
+[ -z $DOCKER_MACHINE_NAME ] && DOCKER_MACHINE_NAME=$(docker-machine ls --filter 'driver=virtualbox' --format '{{.Name}}' | head -n1)
+
+SHARED_FOLDERS="$(VBoxManage showvminfo $DOCKER_MACHINE_NAME  --machinereadable | grep SharedFolder | tr '\r\n' ' ')"
+
+#if ! [[ $SHARED_FOLDERS =~ .*Users.* ]]; then
+#  if docker_machine_state $DOCKER_MACHINE_NAME | grep -qi 'Running' ; then
+#    docker-machine stop $DOCKER_MACHINE_NAME
+#  fi
+#  VBoxManage sharedfolder add dm --name Users --hostpath /Users
+#  VBoxManage setextradata $DOCKER_MACHINE_NAME VBoxInternal2/SharedFoldersEnableSymlinksCreate/Users 1
+#fi
+
+if ! [[ $SHARED_FOLDERS =~ .*rpcm.* ]]; then
+  if docker_machine_state $DOCKER_MACHINE_NAME | grep -qi 'Running' ; then
+    docker-machine stop $DOCKER_MACHINE_NAME
+  fi
+  VBoxManage sharedfolder add $DOCKER_MACHINE_NAME --name rpcm --hostpath /usr/local/rpcm
+  VBoxManage setextradata $DOCKER_MACHINE_NAME VBoxInternal2/SharedFoldersEnableSymlinksCreate/rpcm 1
+fi
+
+#if ! [[ $SHARED_FOLDERS =~ .*x11-fwd.* ]]; then
+#  if docker_machine_state $DOCKER_MACHINE_NAME | grep -qi 'Running' ; then
+#    docker-machine stop $DOCKER_MACHINE_NAME
+#  fi
+#  VBoxManage sharedfolder add dm --name x11-fwd --hostpath $(realpath $(dirname $DISPLAY))
+#  VBoxManage setextradata $DOCKER_MACHINE_NAME VBoxInternal2/SharedFoldersEnableSymlinksCreate/x11-fwd 1
+#fi
+
+[[ "$(docker-machine status $DOCKER_MACHINE_NAME)" != 'Running' ]] && docker-machine start $DOCKER_MACHINE_NAME 
+
+docker-machine ssh $DOCKER_MACHINE_NAME "[ -d /usr/local/rpcm ] || sudo mkdir -p /usr/local/rpcm"
+docker-machine ssh $DOCKER_MACHINE_NAME "sudo mount -t vboxsf -o uid=$(id -u),gid=$(id -g) rpcm /usr/local/rpcm"
+#docker-machine ssh $DOCKER_MACHINE_NAME "[ -d /Users ] || sudo mkdir -p /Users"
+#docker-machine ssh $DOCKER_MACHINE_NAME "sudo mount -t vboxsf -o uid=$(id -u),gid=$(id -g) Users /Users"
+
+# VBox Shared Folder mount (does NOT support file ACLs, and did not work for socket file)
+#docker-machine ssh $DOCKER_MACHINE_NAME "[ -d /tmp/.X11-unix ] || sudo mkdir -p /tmp/.X11-unix"
+#docker-machine ssh $DOCKER_MACHINE_NAME "sudo mount -t vboxsf -o uid=$(id -u),gid=$(id -g),rw,acl x11-fwd /tmp/.X11-unix"
+
+if [ -n "$DISPLAY" -a -x "$(which docker-machine-nfs)" ]; then
+#  docker-machine-nfs $DOCKER_MACHINE_NAME --shared-folder=/Users --mount-opts="rw,acl,async,nolock,vers=3,udp,noatime,actimeo=1"
+  docker-machine ssh $DOCKER_MACHINE_NAME "[ -d $(realpath $(dirname $DISPLAY)) ] || sudo mkdir -p $(realpath $(dirname $DISPLAY))"
+  docker-machine-nfs $DOCKER_MACHINE_NAME --shared-folder=/Users --shared-folder=$(realpath $(dirname $DISPLAY)) --mount-opts="rw,acl,async,nolock,vers=3,udp,noatime,actimeo=1"
+fi

--- a/bin/docker_machine_set_ntp_time.sh
+++ b/bin/docker_machine_set_ntp_time.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+docker_machine_state() {
+  docker_machine_name="$1"
+  docker-machine ls --filter "Name=$docker_machine_name" --format '{{.State}}'
+}
+
+
+DOCKER_MACHINE_NAME=$(docker-machine active 2>/dev/null)
+[ -z $DOCKER_MACHINE_NAME ] && DOCKER_MACHINE_NAME=$(docker-machine ls --filter 'driver=virtualbox' --format '{{.Name}}' | head -n1)
+
+[[ "$(docker-machine status $DOCKER_MACHINE_NAME)" != 'Running' ]] && docker-machine start $DOCKER_MACHINE_NAME
+
+docker-machine ssh $DOCKER_MACHINE_NAME  'tce-load -wi ntpclient.tcz'
+docker-machine ssh $DOCKER_MACHINE_NAME  'ntpclient -c 10 -i 1 -q 300 -l -d -h 0.amazon.pool.ntp.org'

--- a/bin/setup-ansible-env.sh
+++ b/bin/setup-ansible-env.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 REPO_BASE=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 
+# To use: export PIP_USE_SUDO=1
+[[ -n "$PIP_USE_SUDO" && "$PIP_USE_SUDO" == '1' ]] && USE_SUDO='sudo' || USE_SUDO=''
 
 # Configure AWS credentials
 #. ~/secrets/aws_keys.sh
@@ -12,4 +14,4 @@ REPO_BASE=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 export ANSIBLE_HOSTS=${REPO_BASE}/inventory
 
 # Setup Ansible Dynamic Inventory script dependencies
-pip list --format=columns | grep -q ipaddress || pip install -r ${REPO_BASE}/inventory/requirements.txt
+$USE_SUDO pip list --format=columns | grep -q ipaddress || $USE_SUDO pip install -r ${REPO_BASE}/inventory/requirements.txt


### PR DESCRIPTION
### Changes:

- Fixed `docker-run` + `setup-ansible-env.sh` issue with `pip` hanging in deadlock without `sudo`
- Added `boot2docker` & `docker-machine` helper scripts
- Added `docker-machine` create script for newer unofficial `boot2docker.iso` VM creation
  - (silver886/boot2docker#34)

#### Notes:
  - Both `docker-machine` and `boot2docker`
    are marked as Deprecated by the original authors
  - Docker for Mac is now recommended instead
  - Yet, sometimes a minimal Linux Docker VM is still useful!
  - Luckily [silver886 has a fork][1] which appears to be updating the `boot2docker.iso`
  - As of VirtualBox `6.1.28`:
    host-only networks are restricted to `192.168.56.0/21` by default
    References:
     - https://github.com/hashicorp/nomad/pull/11561
     - https://www.virtualbox.org/manual/ch06.html#network_hostonly

 - Creates docker-machine 'dm' with:
   - Docker v20.10.11
   - Linux v5.10.83
   - Tiny Core Linux v12.0
   - Parallels Tools v16.5.0-49183
   - VMware Tools (open-vm-tools) v11.2.5.26209
   - VirtualBox Guest Additions v6.1.30
   - XenServer Tools (xe-guest-utilities) v7.30.0
 - Source: https://github.com/silver886/boot2docker/releases/tag/v20.10.11

[1]: https://github.com/silver886/boot2docker/