### PR TITLE
Update boot2docker and binfmt

### DIFF
--- a/bin/docker_machine_create_dm.sh
+++ b/bin/docker_machine_create_dm.sh
@@ -50,8 +50,3 @@ docker-machine ssh $DOCKER_MACHINE_NAME "sudo VBoxService --only-automount"
 docker-machine ssh $DOCKER_MACHINE_NAME "sudo umount /sf_Users"
 docker-machine ssh $DOCKER_MACHINE_NAME "sudo mkdir /Users; sudo mount -t vboxsf -o uid=$(id -u),gid=$(id -g) Users /Users"
 docker-machine ssh $DOCKER_MACHINE_NAME "sudo mount -t vboxsf -o uid=$(id -u),gid=$(id -g) Users /Users"
-
-# Fix broken tce-load mirror command
-# NOTE: Check mirror URL works when gathered from:
-#       . /etc/init.d/tc-functions ; set -x; getMirror ; set +x
-docker-machine ssh $DOCKER_MACHINE_NAME "sudo /bin/sed -i'' -e 's/VERSION_ID=.*/VERSION_ID=12.0/'  /etc/os-release"

--- a/bin/docker_machine_create_dm.sh
+++ b/bin/docker_machine_create_dm.sh
@@ -24,7 +24,7 @@ errorout() {
 # Create docker-machine 'dm' with:
 #  - Docker v20.10.11
 # Source: https://github.com/silver886/boot2docker/releases/tag/v20.10.11
-BOOT2DOCKER_URL='https://github.com/silver886/boot2docker/releases/download/v20.10.11/boot2docker.iso'
+BOOT2DOCKER_URL='https://github.com/silver886/boot2docker/releases/download/v20.10.12-rc1/boot2docker.iso'
 
 docker-machine create --driver virtualbox \
   --virtualbox-boot2docker-url "$BOOT2DOCKER_URL" \

--- a/bin/docker_machine_setup_arm_binfmt_misc.sh
+++ b/bin/docker_machine_setup_arm_binfmt_misc.sh
@@ -10,17 +10,10 @@ docker_machine_state() {
 DOCKER_MACHINE_NAME=$(docker-machine active 2>/dev/null)
 [ -z $DOCKER_MACHINE_NAME ] && DOCKER_MACHINE_NAME=$(docker-machine ls --filter 'driver=virtualbox' --format '{{.Name}}' | head -n1)
 
-SHARED_FOLDERS="$(VBoxManage showvminfo $DOCKER_MACHINE_NAME  --machinereadable | grep SharedFolder | tr '\r\n' ' ')"
-
 [[ "$(docker-machine status $DOCKER_MACHINE_NAME)" != 'Running' ]] && docker-machine start $DOCKER_MACHINE_NAME
 
-echo "Installing qemu-arm-static to /usr/bin/qemu-arm-static INSIDE docker-machine VM: $DOCKER_MACHINE_NAME"
+echo "Registering qemu-* binfmt_misc handlers INSIDE docker-machine VM: $DOCKER_MACHINE_NAME"
 
-docker-machine ssh $DOCKER_MACHINE_NAME "sudo docker run --rm mazzolino/qemu-arm-static | sudo tee /usr/bin/qemu-arm-static" > /dev/null
-docker-machine ssh $DOCKER_MACHINE_NAME "sudo chmod u+x /usr/bin/qemu-arm-static"
+docker-machine ssh $DOCKER_MACHINE_NAME "sudo docker run --privileged --rm docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64"
 docker-machine ssh $DOCKER_MACHINE_NAME "mount | grep -q binfmt_misc || sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc"
-docker-machine ssh $DOCKER_MACHINE_NAME "[ -f /proc/sys/fs/binfmt_misc/arm ] || echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee /proc/sys/fs/binfmt_misc/register"
 
-# Test that qemu-arm-static is setup via binfmt_misc by running a test ARM container
-docker-machine ssh $DOCKER_MACHINE_NAME "docker run --rm -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static resin/armv7hf-debian echo 'hello from ARM container'"
-docker-machine ssh $DOCKER_MACHINE_NAME "docker run --rm -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static resin/armv7hf-debian uname -a"


### PR DESCRIPTION
`boot2docker` / `docker-machine` related fixes & updates:

* Use official docker/binfmt to register all supported platforms
* Update boot2docker to v20.10.12-rc1 - silver886/boot2docker#37 is fixed!
  * Revert "Fix broken tce-load package manager URIs (workaround silver886/boot2docker#37)" - Fixed in v20.10.12-rc1 silver886/boot2docker#37